### PR TITLE
Swap Typhoeus for RestClient.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rubysl', platform: :rbx
-gem 'typhoeus'
+gem 'rest-client'
 
 gem 'macmillan-utils', git: 'git@github.com:nature/macmillan-utils.git', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,12 +19,12 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
-    ethon (0.7.0)
-      ffi (>= 1.3.0)
-    ffi (1.9.3)
     ffi2-generators (0.1.1)
+    mime-types (2.2)
     multi_json (1.9.3)
     rake (10.3.1)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -243,8 +243,6 @@ GEM
     simplecov-html (0.8.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    typhoeus (0.6.8)
-      ethon (>= 0.7.0)
     webmock (1.17.4)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
@@ -255,7 +253,7 @@ PLATFORMS
 DEPENDENCIES
   macmillan-utils!
   rake
+  rest-client
   rspec
   rubysl
-  typhoeus
   webmock

--- a/bandiera-client.gemspec
+++ b/bandiera-client.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "typhoeus"
+  spec.add_dependency "rest-client"
 end


### PR DESCRIPTION
Typhoeus uses a global Cache which puts Bandiera::Client at the mercy of any
code loaded later than it - we want every request to Bandiera to hit Bandiera
to give us live feature flags.
