### PR TITLE
Set log level for nil user_id/group params to DEBUG

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,7 @@
+= 3.0.2 / 18-February-2016
+
+  * Reduce the log level for missing user_id/user_group params to DEBUG (they were too noisy).
+
 = 3.0.1 / 16-February-2016
 
   * Move the codebase into the `springernature` organisation and update the copyright.

--- a/lib/bandiera/client.rb
+++ b/lib/bandiera/client.rb
@@ -54,7 +54,7 @@ module Bandiera
       default_response = false
       error_msg_prefix = "[Bandiera::Client#get_feature] '#{group} / #{feature} / #{params}'"
 
-      logger.debug "[Bandiera::Client#get_feature] calling #{path} with params: #{params}"
+      logger.debug("[Bandiera::Client#get_feature] calling #{path} with params: #{params}")
 
       get_and_handle_exceptions(path, params, http_opts, default_response, error_msg_prefix)
     end
@@ -76,7 +76,7 @@ module Bandiera
       default_response = {}
       error_msg_prefix = "[Bandiera::Client#get_features_for_group] '#{group} / #{params}'"
 
-      logger.debug "[Bandiera::Client#get_features_for_group] calling #{path} with params: #{params}"
+      logger.debug("[Bandiera::Client#get_features_for_group] calling #{path} with params: #{params}")
 
       get_and_handle_exceptions(path, params, http_opts, default_response, error_msg_prefix)
     end
@@ -94,7 +94,7 @@ module Bandiera
       default_response = {}
       error_msg_prefix = "[Bandiera::Client#get_all] '#{params}'"
 
-      logger.debug "[Bandiera::Client#get_all] calling #{path} with params: #{params}"
+      logger.debug("[Bandiera::Client#get_all] calling #{path} with params: #{params}")
 
       get_and_handle_exceptions(path, params, http_opts, default_response, error_msg_prefix)
     end
@@ -113,7 +113,7 @@ module Bandiera
 
     def get_and_handle_exceptions(path, params, http_opts, return_upon_error, error_msg_prefix, &block)
       res = get(path, params, http_opts)
-      logger.warn "#{error_msg_prefix} - #{res['warning']}" if res['warning']
+      logger.debug("#{error_msg_prefix} - #{res['warning']}") if res['warning']
       block.call(res['response']) if block
       res['response']
     rescue *EXCEPTIONS_TO_HANDLE => error

--- a/lib/bandiera/client/version.rb
+++ b/lib/bandiera/client/version.rb
@@ -1,5 +1,5 @@
 module Bandiera
   class Client
-    VERSION = '3.0.1'.freeze
+    VERSION = '3.0.2'.freeze
   end
 end

--- a/spec/lib/bandiera/client_spec.rb
+++ b/spec/lib/bandiera/client_spec.rb
@@ -69,7 +69,8 @@ describe Bandiera::Client do
         it 'logs the warning' do
           stub = stub_api_request(url, 'response' => false, 'warning' => 'The group does not exist')
 
-          expect(logger).to receive(:warn).once
+          # 2 calls - one for the request, one for the warning
+          expect(logger).to receive(:debug).twice
 
           response = subject.get_feature(group, feature)
 
@@ -149,7 +150,8 @@ describe Bandiera::Client do
         it 'logs the warning' do
           stub = stub_api_request(url, 'response' => {}, 'warning' => 'The group does not exist')
 
-          expect(logger).to receive(:warn).once
+          # 2 calls - one for the request, one for the warning
+          expect(logger).to receive(:debug).twice
 
           response = subject.get_features_for_group(group)
 
@@ -228,7 +230,8 @@ describe Bandiera::Client do
         it 'logs the warning' do
           stub = stub_api_request(url, 'response' => {}, 'warning' => 'The group does not exist')
 
-          expect(logger).to receive(:warn).once
+          # 2 calls - one for the request, one for the warning
+          expect(logger).to receive(:debug).twice
 
           response = subject.get_all
 


### PR DESCRIPTION
They were far too noisy in the production logs at WARN.