### PR TITLE
Reduce warning logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.2
   - 2.3.0
   - ruby
-  - ruby-head
   - jruby
 
 # Ensure we don't build for *every* commit (doesn't apply to PR builds)

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,7 @@
+= 3.0.3 / 11-April-2016
+
+  * Stop the client from logging warnings
+
 = 3.0.2 / 18-February-2016
 
   * Reduce the log level for missing user_id/user_group params to DEBUG (they were too noisy).

--- a/lib/bandiera/client.rb
+++ b/lib/bandiera/client.rb
@@ -116,8 +116,7 @@ module Bandiera
       logger.debug("#{error_msg_prefix} - #{res['warning']}") if res['warning']
       block.call(res['response']) if block
       res['response']
-    rescue *EXCEPTIONS_TO_HANDLE => error
-      logger.warn("#{error_msg_prefix} - #{error.class} - #{error.message}")
+    rescue *EXCEPTIONS_TO_HANDLE
       return_upon_error
     end
 

--- a/lib/bandiera/client/version.rb
+++ b/lib/bandiera/client/version.rb
@@ -1,5 +1,5 @@
 module Bandiera
   class Client
-    VERSION = '3.0.2'.freeze
+    VERSION = '3.0.3'.freeze
   end
 end

--- a/spec/lib/bandiera/client_spec.rb
+++ b/spec/lib/bandiera/client_spec.rb
@@ -81,10 +81,8 @@ describe Bandiera::Client do
     end
 
     context 'bandiera is down' do
-      it 'returns a default response and logs a warning' do
+      it 'returns a default response' do
         stub_request(:get, url).to_return(status: [0, ''])
-
-        expect(logger).to receive(:warn).once
 
         response = subject.get_feature(group, feature)
 
@@ -93,10 +91,8 @@ describe Bandiera::Client do
     end
 
     context 'bandiera is having some problems' do
-      it 'returns a default response and logs a warning' do
+      it 'returns a default response' do
         stub_request(:get, url).to_return(status: 500, body: '')
-
-        expect(logger).to receive(:warn).once
 
         response = subject.get_feature(group, feature)
 
@@ -105,10 +101,8 @@ describe Bandiera::Client do
     end
 
     context 'bandiera times out' do
-      it 'returns a default response and logs a warning' do
+      it 'returns a default response' do
         stub_request(:get, url).to_timeout
-
-        expect(logger).to receive(:warn).once
 
         response = subject.get_feature(group, feature)
 
@@ -162,10 +156,8 @@ describe Bandiera::Client do
     end
 
     context 'bandiera is down' do
-      it 'returns a default response and logs a warning' do
+      it 'returns a default response' do
         stub_request(:get, url).to_return(status: [0, ''])
-
-        expect(logger).to receive(:warn).once
 
         response = subject.get_features_for_group(group)
 
@@ -174,10 +166,8 @@ describe Bandiera::Client do
     end
 
     context 'bandiera is having some problems' do
-      it 'returns a default response and logs a warning' do
+      it 'returns a default response' do
         stub_request(:get, url).to_return(status: 500, body: '')
-
-        expect(logger).to receive(:warn).once
 
         response = subject.get_features_for_group(group)
 
@@ -186,10 +176,8 @@ describe Bandiera::Client do
     end
 
     context 'bandiera times out' do
-      it 'returns a default response and logs a warning' do
+      it 'returns a default response' do
         stub_request(:get, url).to_timeout
-
-        expect(logger).to receive(:warn).once
 
         response = subject.get_features_for_group(group)
 
@@ -242,10 +230,8 @@ describe Bandiera::Client do
     end
 
     context 'bandiera is down' do
-      it 'returns a default response and logs a warning' do
+      it 'returns a default response' do
         stub_request(:get, url).to_return(status: [0, ''])
-
-        expect(logger).to receive(:warn).once
 
         response = subject.get_all
 
@@ -254,10 +240,8 @@ describe Bandiera::Client do
     end
 
     context 'bandiera is having some problems' do
-      it 'returns a default response and logs a warning' do
+      it 'returns a default response' do
         stub_request(:get, url).to_return(status: 200, body: '<html></html>')
-
-        expect(logger).to receive(:warn).once
 
         response = subject.get_all
 
@@ -266,10 +250,8 @@ describe Bandiera::Client do
     end
 
     context 'bandiera times out' do
-      it 'returns a default response and logs a warning' do
+      it 'returns a default response' do
         stub_request(:get, url).to_timeout
-
-        expect(logger).to receive(:warn).once
 
         response = subject.get_all
 


### PR DESCRIPTION
syslog.nature.com messages is filled with warnings from Bandiera. After discussion with @dazoakley he suggested removing the warnings Bandiera passes through in the client. 

> Darren Oakley [12:54 PM] 
> Maybe would be better to modify the client to not log the warnings?

I presume this is what he meant :joy_cat: 