### PR TITLE
[#8] Implement Typhoeus, move to libcurl and add keepalive

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,28 +1,61 @@
+AllCops:
+  StyleGuideCopsOnly: true
+
 Metrics/LineLength:
   Description: 'Limit lines to 120 characters.'
   Max: 120
+  Enabled: true
+
+Metrics/BlockLength:
+  ExcludedMethods:
+    - describe
+    - context
+  Enabled: true
+
+Metrics/MethodLength:
+  CountComments: false
+  Max: 20
+  Enabled: true
+
+Metrics/AbcSize:
+  Max: 40
+  Enabled: true
 
 Style/Documentation:
   Enabled: false
 
-Style/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Enabled: false
 
 Style/BracesAroundHashParameters:
   Enabled: false
 
-Style/IndentHash:
-  EnforcedStyle: consistent
+Style/CaseEquality:
+  Enabled: false
 
-Style/AlignHash:
+Style/GuardClause:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Layout/IndentHash:
+  EnforcedStyle: consistent
+  Enabled: true
+
+Layout/AlignHash:
+  Severity: fatal
+  Enabled: true
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
+  Enabled: true
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+  Enabled: true
 
 Style/CollectionMethods:
   PreferredMethods:
@@ -31,9 +64,41 @@ Style/CollectionMethods:
     inject: 'reduce'
     detect: 'find'
     find_all: 'select'
+  Enabled: true
 
-Style/DotPosition:
+Layout/DotPosition:
   EnforcedStyle: leading
+  Enabled: true
 
 Style/DoubleNegation:
   Enabled: false
+
+Style/Alias:
+  # I like alias_method with symbol parameters
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # with an operator on the previous or next line, not counting empty lines
+  # or comment lines.
+  AllowForAlignment: true
+  Enabled: true
+
+Style/SymbolArray:
+  # Turned off because the associated auto-correct makes a real mess
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  # An 'every file in the repo' recommendation.
+  Enabled: false
+  Severity: warning
+
+Layout/EmptyLineAfterMagicComment:
+  # Nooo not another 'every file in the repo' recommendation.
+  Enabled: false
+  Severity: warning
+
+Style/GlobalVars:
+  # Doesn't justify a critical
+  Enabled: true
+  Severity: warning

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3
+  - 2.4
+  - 2.5
   - jruby-9.0.0.0
 
 # Ensure we don't build for *every* commit (doesn't apply to PR builds)

--- a/bandiera-client.gemspec
+++ b/bandiera-client.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'pry'
 
-  spec.add_dependency 'rest-client'
+  spec.add_dependency 'typhoeus'
   spec.add_dependency 'macmillan-utils'
 end

--- a/lib/bandiera/client/errors.rb
+++ b/lib/bandiera/client/errors.rb
@@ -1,0 +1,12 @@
+module Bandiera
+  class Client
+    class Error < StandardError
+    end
+
+    class TimeoutError < Bandiera::Client::Error
+    end
+
+    class ResponseError < Bandiera::Client::Error
+    end
+  end
+end

--- a/spec/lib/bandiera/client_spec.rb
+++ b/spec/lib/bandiera/client_spec.rb
@@ -62,7 +62,7 @@ describe Bandiera::Client do
 
       expect(Typhoeus::Request)
         .to receive(:new)
-        .with("#{api_uri}/v2/groups/foo/features/bar", method: :get, timeout: 24, open_timeout: 24, headers: {"User-Agent"=>"Bandiera Ruby Client / 3.0.4"}, params: {})
+        .with("#{api_uri}/v2/groups/foo/features/bar", method: :get, timeout: 24, open_timeout: 24, headers: {"User-Agent"=>"Bandiera Ruby Client / #{Bandiera::Client::VERSION}"}, params: {})
         .once
         .and_return(resource)
 


### PR DESCRIPTION
The aim of this pull request is a couple of things:

* Implement #8, as part of a performance improvement at the client level
* Move to Typhoeus as an underlying library. rest_client is great, but moving away from Net::HTTP to a libcurl foundation will provide a sizeable boost on it's own
* Includes the latest macmillan-utils stuff

Let me know what you think?